### PR TITLE
remove special treatment when principal dir is sag

### DIFF
--- a/voxalign/utils.py
+++ b/voxalign/utils.py
@@ -116,14 +116,13 @@ def dicom_orientation_string(normal):
     # [IDL] SIEMENS notation requires modifications IF principal dir. indxs SAG !
     # [PS] In IDL, indxs is the name of the variable that is "secondary" here.
     #      Even with that substitution, I don't understand the comment above.
-    if not principal:
-        if abs(angle_1) > 0:
-            sign1 = angle_1 / abs(angle_1)
-        else:
-            sign1 = 1.0
-
-        angle_1 -= (sign1 * 180.0)
-        angle_2 *= -1
+    # if not principal:
+    #     if abs(angle_1) > 0:
+    #         sign1 = angle_1 / abs(angle_1)
+    #     else:
+    #         sign1 = 1.0
+    #     angle_1 -= (sign1 * 180.0)        
+    #     angle_2 *= -1
     
     if (abs(angle_2) < TOLERANCE) or (abs(abs(angle_2) - 180) < TOLERANCE):
         if (abs(angle_1) < TOLERANCE) or (abs(abs(angle_1) - 180) < TOLERANCE):


### PR DESCRIPTION
not sure if siemens notation has changed since the original IDL code or what, but it doesn't seem like this if statement is needed (yielded incorrect prescription in testing, but need to test more with sag orientations)