### PR TITLE
fix: use -z n to enforce consistent dcm2niix zipping behavior

### DIFF
--- a/voxalign/calc_dice_coef.py
+++ b/voxalign/calc_dice_coef.py
@@ -171,7 +171,7 @@ class DiceApp(QWidget):
                     result = subprocess.run(['cp', sess1T1, 'sess1_T1.nii.gz'], capture_output=True, text=True)
                     result = subprocess.run(['gunzip', 'sess1_T1.nii.gz'], capture_output=True, text=True)
                 elif Path(sess1T1).suffixes[-1] == ".dcm":
-                    result = subprocess.run(['dcm2niix','-f','sess1_T1','-o', outdir,'-s','y',sess1T1], capture_output=True, text=True)
+                    result = subprocess.run(['dcm2niix','-f','sess1_T1','-o', outdir,'-s','y','-z','n',sess1T1], capture_output=True, text=True)
                     print(result)
 
             #skull strip session 1 T1
@@ -190,8 +190,7 @@ class DiceApp(QWidget):
                     result = subprocess.run(['cp', sess2T1, 'sess2_T1.nii.gz'], capture_output=True, text=True)
                     result = subprocess.run(['gunzip', 'sess2_T1.nii.gz'], capture_output=True, text=True)
                 elif Path(sess2T1).suffixes[-1] == ".dcm":
-                    # command = f"dcm2niix -f sess2_T1 -s y {sess2T1}"
-                    result = subprocess.run(['dcm2niix','-f','sess2_T1','-o', outdir,'-s','y',sess2T1], capture_output=True, text=True)
+                    result = subprocess.run(['dcm2niix','-f','sess2_T1','-o', outdir,'-s','y','-z','n',sess2T1], capture_output=True, text=True)
 
             #skull strip session 2 T1
             command = f"cp {sess2T1} ."

--- a/voxalign/main.py
+++ b/voxalign/main.py
@@ -144,7 +144,7 @@ class VoxAlignApp(QWidget):
             sess2T1_dicom_header = pydicom.dcmread(session2_T1_dicom,stop_before_pixels=True)
 
             #convert session 1 T1 DICOM to NIFTI
-            command = f"dcm2niix -f sess1_T1 -o '{output_folder}' -s y {session1_T1_dicom}"
+            command = f"dcm2niix -f sess1_T1 -o '{output_folder}' -s y -z n {session1_T1_dicom}"
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
 
             #skull strip session 1 T1
@@ -153,7 +153,7 @@ class VoxAlignApp(QWidget):
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
 
             # Convert session 2 T1 DICOM to NIFTI
-            command = f"dcm2niix -f sess2_T1 -o '{output_folder}' -s y {session2_T1_dicom}"
+            command = f"dcm2niix -f sess2_T1 -o '{output_folder}' -s y -z n {session2_T1_dicom}"
             result = subprocess.run(command, shell=True, capture_output=True, text=True)
             #skull strip session 2 T1
             print("Skull stripping session 2 T1 ...")

--- a/voxalign/mni_lookup.py
+++ b/voxalign/mni_lookup.py
@@ -342,7 +342,7 @@ class MNILookupApp(QWidget):
                     shutil.copy(os.path.join(self.nonlin_path,file),self.output_folder)
                 
                 #convert new T1 DICOM to NIFTI
-                command = f"dcm2niix -f newT1 -o '{self.output_folder}' -s y {T1_dicom}"
+                command = f"dcm2niix -f newT1 -o '{self.output_folder}' -s y -z n {T1_dicom}"
                 result = subprocess.run(command, shell=True, capture_output=True, text=True)
 
                 #skull strip session 1 T1
@@ -357,7 +357,7 @@ class MNILookupApp(QWidget):
 
             else:            
                 #convert T1 DICOM to NIFTI
-                command = f"dcm2niix -f T1 -o '{self.output_folder}' -s y {T1_dicom}"
+                command = f"dcm2niix -f T1 -o '{self.output_folder}' -s y -z n {T1_dicom}"
                 result = subprocess.run(command, shell=True, capture_output=True, text=True)
 
                 # crop neck from T1


### PR DESCRIPTION
Since we aren't requiring a specific dcm2niix version, we need to use this flag to make sure that output niftis aren't zipped.

Fixes #14 